### PR TITLE
#43 Setup volume for postgres in docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
+# Postgres
+postgresql
+postgres
+
 # Meilisearch
 meilisearch
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,5 @@ services:
       - '5432'
     ports:
       - '127.0.0.1:5432:5432'
-
-volumes:
-  postgres:
+    volumes:
+      - ./postgres:/var/lib/postgresql/data


### PR DESCRIPTION
### Testing
1. `docker-compose up`
2. Load a dump into you local strapi - new folder `postgres` should be created (and gitignored, the same way aj `meilisearch` folder)
3. Start Strapi and check if you have data.
4. Kill strapi and docker container.
5. Go to other repo and do the same
6. Return to this repo, run `docker-compose up`, start Strapi and you should still have all data ✅ 